### PR TITLE
add missing link for elekto test metadata repo

### DIFF
--- a/content/en/docs/Administration/creating.md
+++ b/content/en/docs/Administration/creating.md
@@ -24,7 +24,7 @@ How election Administrators are selected is up to the organization running the e
 
 This YAML file is the main file that creates and configures an election.  It contains multiple configuration variables, most of which can be changed at multiple times during the election. This file is required for the election to be recognized by Elekto, and if it has errors the election will not appear in the Elekto UI.
 
-See the sample elections in [elekto.meta.test]() for examples of these files.
+See the sample elections in [elekto.meta.test](https://github.com/elekto-io/elekto.meta.test/tree/main/elections) for examples of these files.
 
 ### election.yaml variables
 


### PR DESCRIPTION
PR adds the missing link to [elekto.meta.test](https://github.com/elekto-io/elekto.meta.test/) repo in https://elekto.dev/docs/administration/creating/#electionyaml-variables

![image](https://github.com/user-attachments/assets/afe129fe-e000-4de1-8d64-8f876f896cd8)


/assign @jberkus 